### PR TITLE
Chase head on cweagans/composer-patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "require": {
         "composer/installers": "^1.0.20",
         "drupal-composer/drupal-scaffold": "^1.2",
-        "cweagans/composer-patches": "~1.0",
+        "cweagans/composer-patches": "dev-master",
         "drupal/lightning": "8.1.*",
         "drupal/core": "8.1.*",
         "drupal/address": "8.1.x-dev",


### PR DESCRIPTION
We need to chase head on cweagans/composer-patches because he hasn't tagged a release since we contributed a fix to patch dependencies of dependencies. See https://github.com/cweagans/composer-patches/pull/36
