### PR TITLE
Patched Panelizer and Workbench Moderation to support QuickEdit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,9 @@
             },
             "drupal/panelizer": {
                 "Explicitly set the Panels IPE URL root when saving in Panelizer | https://www.drupal.org/node/2700597":
-                "https://www.drupal.org/files/issues/2546204-6.patch"
+                "https://www.drupal.org/files/issues/2546204-6.patch",
+                "Quickedit support for fields displayed using the ctools_field block. | https://www.drupal.org/node/2693163":
+                "https://www.drupal.org/files/issues/panelizer-quickedit-2693163-3.patch"
             },
             "drupal/panels": {
                 "Allow other modules to disable the IPE based on custom logic | https://www.drupal.org/node/2667754":
@@ -163,7 +165,9 @@
                 "Replace the workbench moderation form with a block | https://www.drupal.org/node/2685163":
                 "https://www.drupal.org/files/issues/2685163-19.patch",
                 "allow for latest revision to be used in views | https://www.drupal.org/node/2702041":
-                "https://www.drupal.org/files/issues/2702041-20.patch"
+                "https://www.drupal.org/files/issues/2702041-20.patch",
+                "Add basic support for QuickEdit | https://www.drupal.org/node/2749503":
+                "https://www.drupal.org/files/issues/workbench_moderation-quickedit-support.patch"
             },
             "drupal/adminimal_theme": {
                 "Fix styling so that admin_toolbar can be used | https://www.drupal.org/node/2680689":

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -232,6 +232,9 @@ projects[panelizer][version] = "3.0-alpha2"
 ; Explicitly set the Panels IPE URL root when saving in Panelizer
 ; https://www.drupal.org/node/2700597
 projects[panelizer][patch][2700597] = "https://www.drupal.org/files/issues/panelizer-ipe-url-root-handling.patch"
+; Quickedit support for fields displayed using the ctools_field block.
+; https://www.drupal.org/node/2693163
+projects[panelizer][patch][2693163] = "https://www.drupal.org/files/issues/panelizer-quickedit-2693163-3.patch"
 
 projects[pathauto][version] = "1.x-dev"
 projects[pathauto][type] = "module"
@@ -285,7 +288,9 @@ projects[workbench_moderation][patch][2685163] = "https://www.drupal.org/files/i
 ;allow for latest revision to be used in views
 ;https://www.drupal.org/node/2702041
 projects[workbench_moderation][patch][2702041] = "https://www.drupal.org/files/issues/2702041-20.patch"
-
+; Add basic support for QuickEdit
+;https://www.drupal.org/node/2749503
+projects[workbench_moderation][patch][2749503] = "https://www.drupal.org/files/issues/workbench_moderation-quickedit-support.patch"
 
 ; Libraries
 libraries[dropzone][destination] = "../../libraries"


### PR DESCRIPTION
This pull request intends to add QuickEdit support to our demo by adding a custom QuickEdit render pipeline to Panelizer, and by loading the correct revision when QuickEditing Drafts in Workbench Moderation.

See: https://www.drupal.org/node/2693163 and https://www.drupal.org/node/2749503
