### PR TITLE
Fix "Undefined index: #attached" notices thrown in Panelizer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,9 @@
                 "Explicitly set the Panels IPE URL root when saving in Panelizer | https://www.drupal.org/node/2700597":
                 "https://www.drupal.org/files/issues/2546204-6.patch",
                 "Quickedit support for fields displayed using the ctools_field block. | https://www.drupal.org/node/2693163":
-                "https://www.drupal.org/files/issues/panelizer-quickedit-2693163-2.patch"
+                "https://www.drupal.org/files/issues/panelizer-quickedit-2693163-2.patch",
+                "Undefined index: #attached | https://www.drupal.org/node/2760051":
+                "https://www.drupal.org/files/issues/check-for-build-array-keys-2760051_1.patch"
             },
             "drupal/panels": {
                 "IPE's cancel button is easy to mistake for a button to close the tray (rather than throw away all changes). | https://www.drupal.org/node/2636490":


### PR DESCRIPTION
Making a PR so that I can test patches before merging, but this should be harmless.
