### PR TITLE
Update Entity Browser related code to match recent changes.

### DIFF
--- a/themes/dfs_base/js/dfs_base.js
+++ b/themes/dfs_base/js/dfs_base.js
@@ -73,22 +73,10 @@
           // Make the modal full width.
           $modal.dialog({
             width: '100%',
-            height: $(window).height(),
-            buttons: [{
-              text: Drupal.t('Select'),
-              click: function(e) {
-                $child.contents().find('#edit-actions-wrap input').click();
-                e.preventDefault();
-                e.stopPropagation();
-              }
-            }]
+            height: $(window).height()
           });
           $modal.parent().addClass('ui-dialog-full-width');
           $child.css('height', $modal.innerHeight());
-
-          $child.on('load', function() {
-            $child.contents().find('#edit-actions-wrap').hide();
-          });
         }
       }
     }


### PR DESCRIPTION
My work at NYCCamp broke a few things that require us to go back to requiring dev releases of Entity Browser and DropzoneJS. I think a good policy would be to require `8.x-1.x-dev` of these modules during development, then tie to a commit/recent release when we do a stable release. Then if we _really_ need to go back to dev again, we can do that later.
