### PR TITLE
Ignore the Panels bandaid patch and remove the related test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/DevinCarlson/composer-patches"
+            "url": "https://github.com/mortenson/composer-patches"
         },
         {
             "type": "package",
@@ -180,6 +180,14 @@
             "lite": {
                 "CKLite interferes with content insertion | http://drupal.org/node/2482879":
                 "https://www.drupal.org/files/issues/cklite-content-insertion-2482879-4.patch"
+            }
+        },
+        "patches-ignore": {
+            "drupal/lightning": {
+                "drupal/panels": {
+                    "Bandaid patch breaking save after previewing blocks with Panelizer":
+                    "https://www.drupal.org/files/issues/bandaid.patch"
+                }
             }
         }
     },

--- a/tests/features/df/df.panelizer.feature
+++ b/tests/features/df/df.panelizer.feature
@@ -29,16 +29,17 @@ Feature: Panelizer
     And I reload the page
     Then I should see a "block_content:test--here-be-dragons" block with a "quickedit" contextual link
 
-  @javascript
-  Scenario: Editing layouts does not affect other layouts if the user has not saved the edited layout as default
-    Given I am logged in as a user with the administrator role
-    And landing_page content:
-      | title   | path     | moderation_state |
-      | Layout1 | /layout1 | draft            |
-      | Layout2 | /layout2 | draft            |
-    When I visit "/layout1"
-    And I place the "views_block:who_s_online-who_s_online_block" block from the "Lists" category
-    # And visit the second landing page without saving the layout changes to the first
-    And I visit "/layout2"
-    # I should not see the block placed by the first landing page
-    Then I should not see a "views_block:who_s_online-who_s_online_block" block
+# @todo Update when https://github.com/acquia/lightning/pull/145 is closed.
+#  @javascript
+#  Scenario: Editing layouts does not affect other layouts if the user has not saved the edited layout as default
+#    Given I am logged in as a user with the administrator role
+#    And landing_page content:
+#      | title   | path     | moderation_state |
+#      | Layout1 | /layout1 | draft            |
+#      | Layout2 | /layout2 | draft            |
+#    When I visit "/layout1"
+#    And I place the "views_block:who_s_online-who_s_online_block" block from the "Lists" category
+#    # And visit the second landing page without saving the layout changes to the first
+#    And I visit "/layout2"
+#    # I should not see the block placed by the first landing page
+#    Then I should not see a "views_block:who_s_online-who_s_online_block" block


### PR DESCRIPTION
See https://github.com/acquia/lightning/pull/145 for related history. This PR should fix the bandaid issues we're seeing with the Lightning release we're tied to.
