### PR TITLE
Use profile tests folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,8 @@ install:
   - phing install -Ddb.database=drupal -Ddb.user=df -Ddb.password=df -Ddb.host=127.0.0.1
 
   # Generate Behat configuration.
-  - drupal behat:init http://127.0.0.1:8080 --merge=../tests/behat.yml
-  - drupal behat:include ../tests/features --with-subcontexts=../tests/features/bootstrap --with-subcontexts=../src/DFExtension/Context
+  - drupal behat:init http://127.0.0.1:8080 --merge=../docroot/profiles/df/tests/behat.yml
+  - drupal behat:include ../docroot/profiles/df/tests/features --with-subcontexts=../docroot/profiles/df/tests/features/bootstrap --with-subcontexts=../docroot/profiles/df/src/DFExtension/Context
 
   # Import the fixture, if it exists.
   - phing recall -Dversion=$VERSION -Ddb.database=drupal -Ddb.user=df -Ddb.password=df -Ddb.host=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ tests:
 
 ### Behat
     $ cd MYPROJECT
-    $ ./bin/drupal behat:init http://YOUR.DF.SITE --merge=../tests/behat.yml
-    $ ./bin/drupal behat:include ../tests/features --with-subcontexts=../tests/features/bootstrap --with-subcontexts=../src/LightningExtension/Context
+    $ ./bin/drupal behat:init http://YOUR.DF.SITE --merge=../docroot/profiles/df/tests/behat.yml
+    $ ./bin/drupal behat:include ../docroot/profiles/df/tests/features --with-subcontexts=../docroot/profiles/df/tests/features/bootstrap --with-subcontexts=../docroot/profiles/df/src/DFExtension/Context
     $ ./bin/behat --config ./docroot/sites/default/files/behat.yml
 
 If necessary, you can edit ```docroot/sites/default/files/behat.yml``` to match

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -25,8 +25,8 @@ events:
             - ./bin/phing cloud-db-snippet
             - mkdir -p ./config/default
             # Generate Behat configuration.
-            - ./bin/drupal behat:init http://127.0.0.1:8080 --merge=../tests/behat.yml
-            - ./bin/drupal behat:include ../tests/features --with-subcontexts=../tests/features/bootstrap --with-subcontexts=../src/DFExtension/Context
+            - ./bin/drupal behat:init http://127.0.0.1:8080 --merge=../docroot/profiles/df/tests/behat.yml
+            - ./bin/drupal behat:include ../docroot/profiles/df/tests/features --with-subcontexts=../docroot/profiles/df/tests/features/bootstrap --with-subcontexts=../docroot/profiles/df/src/DFExtension/Context
       - test:
           type: script
           script:

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -35,4 +35,4 @@ events:
             - ../bin/drush runserver --default-server=builtin 8080 &>/dev/null &
             - ../bin/phantomjs --webdriver=4444 > /dev/null &
             - sleep 10
-            - ../bin/behat --stop-on-failure --config ./sites/default/files/behat.yml --tags=df&&~javascript
+            - ../bin/behat --stop-on-failure --config ./sites/default/files/behat.yml --tags='df&&~javascript'


### PR DESCRIPTION
Updated Travis, changing dynamic behat configuration to use tests located within the profile/tests directory instead of the root/tests directory.