### PR TITLE
Fix profile array bug.

### DIFF
--- a/df.info.yml
+++ b/df.info.yml
@@ -2,8 +2,8 @@ name: 'Demo Framework'
 type: profile
 description: 'Architects start here.'
 core: 8.x
-'base profile': lightning
-dependencies:
+base profile: lightning
+install:
   - admin_login_path
   - admin_toolbar
   - admin_toolbar_tools

--- a/profiles/dfs_one/dfs_one.info.yml
+++ b/profiles/dfs_one/dfs_one.info.yml
@@ -3,8 +3,8 @@ type: profile
 description: 'Demo Framework Scenario for One.'
 core: 8.x
 package: 'Demo Framework Scenarios'
-'base profile': df
-dependencies:
+base profile: df
+install:
   - color
   - df_tools_articles
   - df_tools_blocks


### PR DESCRIPTION
This fixes a bug in the df and dfs_one info.yml syntax which is required to install subprofiles / df / dfs_one successfully. Otherwise, the errors pasted below will fail the install:
```
Standard error: [notice] Starting Drupal installation. This takes a while.
 [warning] Illegal offset type ProfileExtensionList.php:183
 [warning] Illegal offset type ProfileExtensionList.php:150
 [warning] array_merge(): Argument #2 is not an array ProfileExtensionList.php:157
 [warning] array_diff(): Argument #1 is not an array ProfileExtensionList.php:157
 [warning] array_merge(): Argument #2 is not an array ProfileExtensionList.php:158
 [warning] array_diff(): Argument #1 is not an array ProfileExtensionList.php:158
 [warning] array_unique() expects parameter 1 to be array, null given ProfileExtensionList.php:160
 [warning] array_unique() expects parameter 1 to be array, null given ProfileExtensionList.php:161
 [warning] strpos() expects parameter 1 to be string, array given Dependency.php:181
 [warning] explode() expects parameter 2 to be string, array given Dependency.php:182
 [warning] array_map(): Argument #2 should be an array install.inc:1124
 [warning] Illegal offset type in isset or empty ExtensionList.php:259
```

See https://www.drupal.org/project/lightning_core/issues/2997990