### PR TITLE
Update CKEditor to CKEditor 5.

### DIFF
--- a/modules/df/df_core/df_core.info.yml
+++ b/modules/df/df_core/df_core.info.yml
@@ -10,7 +10,7 @@ dependencies:
   - admin_toolbar
   - admin_toolbar_tools
   - block_content
-  - ckeditor
+  - ckeditor5
   - collapsiblock
   - color
   - config


### PR DESCRIPTION
**Motivation**
Demo Framework uses CKEditor 5 for all of its profile, but it also installs CKEditor 4 even though it is not using it. CKEditor 4 has been deprecated and should not be installed

**Proposed changes**
DF Core should update to using CKEditor 5.

