### PR TITLE
Adds DF Tools Augmentor.

### DIFF
--- a/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_summary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - augmentor
+    - node
+id: node.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+type: field_augmentor_type
+settings: {  }
+module: augmentor
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_tags.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - augmentor
+    - node
+id: node.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+type: field_augmentor_type
+settings: {  }
+module: augmentor
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_title.yml
+++ b/modules/df/df_tools/df_tools_augmentor/config/install/field.storage.node.field_suggest_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - augmentor
+    - node
+id: node.field_suggest_title
+field_name: field_suggest_title
+entity_type: node
+type: field_augmentor_type
+settings: {  }
+module: augmentor
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/df/df_tools/df_tools_augmentor/config/install/key.key.open_ai.yml
+++ b/modules/df/df_tools/df_tools_augmentor/config/install/key.key.open_ai.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+id: open_ai
+label: 'Open AI'
+description: 'Key for Open AI.'
+key_type: authentication
+key_type_settings: {  }
+key_provider: config
+key_provider_settings:
+  key_value: ''
+key_input: text_field
+key_input_settings: {  }

--- a/modules/df/df_tools/df_tools_augmentor/config/rewrite/augmentor.settings.yml
+++ b/modules/df/df_tools/df_tools_augmentor/config/rewrite/augmentor.settings.yml
@@ -1,0 +1,88 @@
+augmentors:
+  bc6eff21-6421-46ae-924f-2d65728fb18c:
+    label: 'ChatGPT Title'
+    weight: 0
+    type: chatgpt
+    configuration:
+      label: 'ChatGPT Title'
+      uuid: bc6eff21-6421-46ae-924f-2d65728fb18c
+      id: chatgpt
+      weight: ''
+      key: open_ai
+      settings:
+        label: 'ChatGPT Title'
+        key: open_ai
+        model: gpt-3.5-turbo
+        messages:
+          0:
+            role: system
+            content: 'You are a helpful assistant.'
+          1:
+            role: user
+            content: "Suggest three SEO friendly titles for this page based off of the following content in 10 words or less, in the same language as the input:\r\n\r\n{input}"
+          actions: {  }
+        temperature: '1'
+        max_tokens: '100'
+        top_p: '0'
+        'n': '1'
+        frequency_penalty: '0'
+        presence_penalty: '0'
+        user_tracking: 1
+  78614461-55ae-4b0e-b2b0-56ce77e3286f:
+    label: 'ChatGPT Summarize'
+    weight: 1
+    type: chatgpt
+    configuration:
+      label: ''
+      uuid: ''
+      id: chatgpt
+      weight: 1
+      key: ''
+      settings:
+        label: 'ChatGPT Summarize'
+        key: open_ai
+        model: gpt-3.5-turbo
+        messages:
+          0:
+            role: system
+            content: 'You are a helpful assistant.'
+          1:
+            role: user
+            content: "Create an SEO friendly meta description of up to 200 characters for the following text, using the same language as the input:\r\n\r\n{input}"
+          actions: {  }
+        temperature: '1'
+        max_tokens: '60'
+        top_p: '0'
+        'n': '1'
+        frequency_penalty: '0'
+        presence_penalty: '0'
+        user_tracking: 1
+  3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee:
+    label: 'ChatGPT Tags'
+    weight: 2
+    type: chatgpt
+    configuration:
+      label: ''
+      uuid: ''
+      id: chatgpt
+      weight: 2
+      key: ''
+      settings:
+        label: 'ChatGPT Tags'
+        key: open_ai
+        model: gpt-3.5-turbo
+        messages:
+          0:
+            role: system
+            content: 'You are a helpful assistant.'
+          1:
+            role: user
+            content: "Extract keywords from this text and comma separate them:\r\n\r\n{input}"
+          actions: {  }
+        temperature: '1'
+        max_tokens: '40'
+        top_p: '0'
+        'n': '1'
+        frequency_penalty: '0'
+        presence_penalty: '0'
+        user_tracking: 1

--- a/modules/df/df_tools/df_tools_augmentor/df_tools_augmentor.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/df_tools_augmentor.info.yml
@@ -1,0 +1,10 @@
+name: DF Tools Augmentor
+type: module
+description: Base config for Augmentor.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:augmentor
+  - drupal:augmentor_ckeditor5
+  - drupal:augmentor_chatgpt
+  - drupal:key

--- a/modules/df/df_tools/df_tools_augmentor/df_tools_augmentor.install
+++ b/modules/df/df_tools/df_tools_augmentor/df_tools_augmentor.install
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Implements hook_module_install().
+ */
+function df_tools_augmentor_install($is_syncing) {
+  if (!$is_syncing) {
+    $moduleHandler = \Drupal::service('module_handler');
+    $moduleInstaller = \Drupal::service('module_installer');
+
+    // Installs DF Tools Augmentor Article.
+    if ($moduleHandler->moduleExists('df_tools_article')) {
+      $moduleInstaller->install(['df_tools_augmentor_article']);
+    }
+
+     // Installs DF Tools Augmentor Event.
+    if ($moduleHandler->moduleExists('df_tools_event')) {
+      $moduleInstaller->install(['df_tools_augmentor_event']);
+    }
+
+     // Installs DF Tools Augmentor Person.
+    if ($moduleHandler->moduleExists('df_tools_person')) {
+      $moduleInstaller->install(['df_tools_augmentor_person']);
+    }
+
+     // Installs DF Tools Augmentor Place.
+    if ($moduleHandler->moduleExists('df_tools_place')) {
+      $moduleInstaller->install(['df_tools_augmentor_place']);
+    }
+
+    // Installs DF Tools Augmentor Product.
+    if ($moduleHandler->moduleExists('df_tools_product')) {
+      $moduleInstaller->install(['df_tools_augmentor_product']);
+    }
+  }
+}

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_summary
+    - node.type.article
+  module:
+    - augmentor
+id: node.article.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+bundle: article
+label: 'Suggest body summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_tags
+    - node.type.article
+  module:
+    - augmentor
+id: node.article.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+bundle: article
+label: 'Suggest tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_title.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/install/field.field.node.article.field_suggest_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_title
+    - node.type.article
+  module:
+    - augmentor
+id: node.article.field_suggest_title
+field_name: field_suggest_title
+entity_type: node
+bundle: article
+label: 'Suggest title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/rewrite/core.entity_form_display.node.article.default.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/config/rewrite/core.entity_form_display.node.article.default.yml
@@ -1,0 +1,97 @@
+dependencies:
+  config:
+    - field.field.node.article.field_suggest_summary
+    - field.field.node.article.field_suggest_tags
+    - field.field.node.article.field_suggest_title
+  module:
+    - augmentor
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_categories
+        - field_suggest_tags
+        - field_tags
+        - field_article_type
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+        required_fields: true
+mode: default
+content:
+  field_categories:
+    weight: 7
+  field_suggest_summary:
+    type: augmentor_summary_widget
+    weight: 1
+    region: content
+    settings:
+      targets:
+        0:
+          target_field: body
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 78614461-55ae-4b0e-b2b0-56ce77e3286f
+      action: replace
+      trim: none
+      button_label: 'Suggest body summary'
+      source_fields: {  }
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_tags:
+    type: augmentor_tags_widget
+    weight: 9
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: field_tags
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee
+      action: append
+      trim: none
+      button_label: 'Suggest tags'
+      explode_separator: ','
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_title:
+    type: augmentor_select_regex_widget
+    weight: -1
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: title
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: bc6eff21-6421-46ae-924f-2d65728fb18c
+      action: replace
+      trim: none
+      button_label: 'Suggest a title'
+      regex: '/\d\. "(.*)"/gim'
+      explode_separator: \n
+      result_pattern: $1
+      match_index: ''
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    weight: 8
+  title:
+    weight: -2

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/df_tools_augmentor_article.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_article/df_tools_augmentor_article.info.yml
@@ -1,0 +1,9 @@
+name: DF Tools Augmentor Article
+type: module
+description: Sets up Augmentor for Articles.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:config_rewrite
+  - drupal:df_tools_article
+  - drupal:df_tools_augmentor

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_summary
+    - node.type.event
+  module:
+    - augmentor
+id: node.event.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+bundle: event
+label: 'Suggest description summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_tags
+    - node.type.event
+  module:
+    - augmentor
+id: node.event.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+bundle: event
+label: 'Suggest tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_title.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/install/field.field.node.event.field_suggest_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_title
+    - node.type.event
+  module:
+    - augmentor
+id: node.event.field_suggest_title
+field_name: field_suggest_title
+entity_type: node
+bundle: event
+label: 'Suggest title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/rewrite/core.entity_form_display.node.event.default.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/config/rewrite/core.entity_form_display.node.event.default.yml
@@ -1,0 +1,95 @@
+dependencies:
+  config:
+    - field.field.node.event.field_suggest_summary
+    - field.field.node.event.field_suggest_tags
+    - field.field.node.event.field_suggest_title
+  module:
+    - augmentor
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_suggest_tags
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+        required_fields: true
+mode: default
+content:
+  field_categories:
+    weight: 10
+  field_suggest_summary:
+    type: augmentor_summary_widget
+    weight: 1
+    region: content
+    settings:
+      targets:
+        0:
+          target_field: body
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 78614461-55ae-4b0e-b2b0-56ce77e3286f
+      action: replace
+      trim: none
+      button_label: 'Suggest description summary'
+      source_fields: {  }
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_tags:
+    type: augmentor_tags_widget
+    weight: 12
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: field_tags
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee
+      action: append
+      trim: none
+      button_label: 'Suggest tags'
+      explode_separator: ','
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_title:
+    type: augmentor_select_regex_widget
+    weight: -1
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: title
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: bc6eff21-6421-46ae-924f-2d65728fb18c
+      action: replace
+      trim: none
+      button_label: 'Suggest a Title'
+      regex: '/\d\. "(.*)"/gim'
+      explode_separator: \n
+      result_pattern: $1
+      match_index: ''
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    weight: 11
+  title:
+    weight: -2

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/df_tools_augmentor_event.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_event/df_tools_augmentor_event.info.yml
@@ -1,0 +1,9 @@
+name: DF Tools Augmentor Event
+type: module
+description: Sets up Augmentor for Events.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:config_rewrite
+  - drupal:df_tools_event
+  - drupal:df_tools_augmentor

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/install/field.field.node.person.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/install/field.field.node.person.field_suggest_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_summary
+    - node.type.person
+  module:
+    - augmentor
+id: node.person.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+bundle: person
+label: 'Suggest bio summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/install/field.field.node.person.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/install/field.field.node.person.field_suggest_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_tags
+    - node.type.person
+  module:
+    - augmentor
+id: node.person.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+bundle: person
+label: 'Suggest tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/rewrite/core.entity_form_display.node.person.default.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/config/rewrite/core.entity_form_display.node.person.default.yml
@@ -1,0 +1,68 @@
+dependencies:
+  config:
+    - field.field.node.person.field_suggest_summary
+    - field.field.node.person.field_suggest_tags
+  module:
+    - augmentor
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_suggest_tags
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+        required_fields: true
+mode: default
+content:
+  field_categories:
+    weight: 6
+  field_suggest_summary:
+    type: augmentor_summary_widget
+    weight: 2
+    region: content
+    settings:
+      targets:
+        0:
+          target_field: body
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 78614461-55ae-4b0e-b2b0-56ce77e3286f
+      action: replace
+      trim: none
+      button_label: 'Suggest bio summary'
+      source_fields: {  }
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_tags:
+    type: augmentor_tags_widget
+    weight: 8
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: field_tags
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee
+      action: append
+      trim: none
+      button_label: 'Suggest tags'
+      explode_separator: ','
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    weight: 7

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/df_tools_augmentor_person.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_person/df_tools_augmentor_person.info.yml
@@ -1,0 +1,9 @@
+name: DF Tools Augmentor Person
+type: module
+description: Sets up Augmentor for Person.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:config_rewrite
+  - drupal:df_tools_person
+  - drupal:df_tools_augmentor

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/install/field.field.node.place.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/install/field.field.node.place.field_suggest_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_summary
+    - node.type.place
+  module:
+    - augmentor
+id: node.place.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+bundle: place
+label: 'Suggest description summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/install/field.field.node.place.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/install/field.field.node.place.field_suggest_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_tags
+    - node.type.place
+  module:
+    - augmentor
+id: node.place.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+bundle: place
+label: 'Suggest tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/rewrite/core.entity_form_display.node.place.default.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/config/rewrite/core.entity_form_display.node.place.default.yml
@@ -1,0 +1,68 @@
+dependencies:
+  config:
+    - field.field.node.place.field_suggest_summary
+    - field.field.node.place.field_suggest_tags
+  module:
+    - augmentor
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_suggest_tags
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+        required_fields: true
+mode: default
+content:
+  field_categories:
+    weight: 4
+  field_suggest_summary:
+    type: augmentor_summary_widget
+    weight: 1
+    region: content
+    settings:
+      targets:
+        0:
+          target_field: body
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 78614461-55ae-4b0e-b2b0-56ce77e3286f
+      action: replace
+      trim: none
+      button_label: 'Suggest description summary'
+      source_fields: {  }
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_tags:
+    type: augmentor_tags_widget
+    weight: 6
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: field_tags
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee
+      action: append
+      trim: none
+      button_label: 'Suggest tags'
+      explode_separator: ','
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    weight: 5

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/df_tools_augmentor_place.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_place/df_tools_augmentor_place.info.yml
@@ -1,0 +1,9 @@
+name: DF Tools Augmentor Place
+type: module
+description: Sets up Augmentor for Places.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:config_rewrite
+  - drupal:df_tools_place
+  - drupal:df_tools_augmentor

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/install/field.field.node.product.field_suggest_summary.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/install/field.field.node.product.field_suggest_summary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_summary
+    - node.type.product
+  module:
+    - augmentor
+id: node.product.field_suggest_summary
+field_name: field_suggest_summary
+entity_type: node
+bundle: product
+label: 'Suggest description summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/install/field.field.node.product.field_suggest_tags.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/install/field.field.node.product.field_suggest_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_suggest_tags
+    - node.type.product
+  module:
+    - augmentor
+id: node.product.field_suggest_tags
+field_name: field_suggest_tags
+entity_type: node
+bundle: product
+label: 'Suggest tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: field_augmentor_type

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/rewrite/core.entity_form_display.node.product.default.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/config/rewrite/core.entity_form_display.node.product.default.yml
@@ -1,0 +1,64 @@
+dependencies:
+  config:
+    - field.field.node.place.field_suggest_summary
+    - field.field.node.place.field_suggest_tags
+  module:
+    - augmentor
+third_party_settings:
+  field_group:
+    group_taxonomy:
+      children:
+        - field_suggest_tags
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        id: ''
+        description: ''
+        required_fields: true
+mode: default
+content:
+  field_suggest_summary:
+    type: augmentor_summary_widget
+    weight: 6
+    region: content
+    settings:
+      targets:
+        0:
+          target_field: body
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 78614461-55ae-4b0e-b2b0-56ce77e3286f
+      action: replace
+      trim: none
+      button_label: 'Suggest description summary'
+      source_fields: {  }
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }
+  field_suggest_tags:
+    type: augmentor_tags_widget
+    weight: 28
+    region: content
+    settings:
+      source_fields:
+        - body
+      targets:
+        0:
+          target_field: field_tags
+          key: default
+        actions:
+          add_target: 'Add one more target'
+      augmentor: 3f24ecda-9858-41a0-bf77-eb5cfeb2e1ee
+      action: append
+      trim: none
+      button_label: 'Suggest tags'
+      explode_separator: ','
+      rows: '5'
+      placeholder: ''
+    third_party_settings: {  }

--- a/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/df_tools_augmentor_product.info.yml
+++ b/modules/df/df_tools/df_tools_augmentor/modules/df_tools_augmentor_product/df_tools_augmentor_product.info.yml
@@ -1,0 +1,9 @@
+name: DF Tools Augmentor Product
+type: module
+description: Sets up Augmentor for Products.
+core_version_requirement: ^9 || ^10
+package: Demo Framework Tools
+dependencies:
+  - drupal:config_rewrite
+  - drupal:df_tools_product
+  - drupal:df_tools_augmentor


### PR DESCRIPTION
**Motivation**
[Augmentor](https://www.drupal.org/project/augmentor) is a powerful module that can be complex to configure. To make it easier on SEs, we should create a DF Tools module for Augmentor.

**Testing steps**
- Install DF
- Install DF Tools Article, DF Tools Event, DF Tools Person, DF Tools Place
- Install DF Tools Augmentor
- Edit the Open AI key and provide a key for Open AI /admin/config/system/keys/manage/open_ai
- Create an Article and provide a body.
- With content in the body, you can use Suggest a title, Suggest body summary and 
Suggest tag fields to use ChatGPT to populate the fields from the body.