### PR TITLE
Removes Tour from DF Core.

### DIFF
--- a/modules/df/df_core/df_core.info.yml
+++ b/modules/df/df_core/df_core.info.yml
@@ -39,7 +39,6 @@ dependencies:
   - search_api_autocomplete
   - search_api_db
   - syslog
-  - tour
   - view_modes_display
   - views_ui
   - webform


### PR DESCRIPTION
The Tour module is currently installed by default in [DF Core](https://github.com/acquia/df/blob/7.x/modules/df/df_core/df_core.info.yml#L42). However, this module is not needed in many use cases. It should not be included in the DF Core.
