### PR TITLE
Removes Color from DF Core.

### DIFF
--- a/modules/df/df_core/df_core.info.yml
+++ b/modules/df/df_core/df_core.info.yml
@@ -12,7 +12,6 @@ dependencies:
   - block_content
   - ckeditor5
   - collapsiblock
-  - color
   - config
   - config_delete
   - config_rewrite


### PR DESCRIPTION
The Color module is currently installed by default in [DF Core](https://github.com/acquia/df/blob/7.x/modules/df/df_core/df_core.info.yml#L15). However, this module is not needed in many use cases. It should not be included in the DF Core.
